### PR TITLE
Add GitHub Actions release workflow and update GoReleaser config

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,60 +9,227 @@ permissions:
   contents: write
 
 jobs:
-  # Build Job: Compiles the binaries
+  # Build Job: Compiles the binaries on Linux and macOS (matrix) and uploads artifacts
   build:
-    runs-on: ubuntu-latest
-    outputs:
-      release_dir: ${{ steps.set_release_dir.outputs.release_dir }}
+    name: Build and Verify Release Binaries
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Set Up Go
         uses: actions/setup-go@v4
         with:
           go-version: '1.21.4'
 
-      - name: Build Binaries
-        id: build_binaries
+      - name: Download modules
+        run: go mod download
+
+      - name: Build binary
         run: |
           mkdir -p dist
-          go build -o dist/fmsh cmd/main.go
+          # Use RUNNER_OS to differentiate runner platforms (Linux vs macOS)
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            go build -o dist/fmsh-darwin-amd64 ./cmd
+          else
+            go build -o dist/fmsh-linux-amd64 ./cmd
+          fi
 
-      - name: Set Output Directory
-        id: set_release_dir
-        run: echo "::set-output name=release_dir::dist"
+      - name: Set artifact name
+        id: set-name
+        run: |
+          if [ "$RUNNER_OS" = "macOS" ]; then
+            echo "name=macos" >> $GITHUB_OUTPUT
+          else
+            echo "name=linux" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: fmsh-${{ steps.set-name.outputs.name }}
+          path: dist/
 
   # Package Job: Packages artifacts
   package:
     runs-on: ubuntu-latest
     needs: build
-    outputs:
-      dist-dir: ${{ steps.package.outputs.dist-dir }}
     steps:
       - name: Checkout Code
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v4
         with:
           distribution: goreleaser
           version: latest
+          # Run goreleaser in real release mode so it creates a GitHub Release
+          # (ensure a PAT is set in secrets as GH_PAT with appropriate scopes)
           args: release --clean
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Use GH_PAT (a PAT with repo+workflow scopes) for release API actions
+          GITHUB_TOKEN: ${{ secrets.GH_PAT }}
 
       - name: Set Output Directory for Deployment
         id: package
-        run: echo "::set-output name=dist-dir::dist"
+        run: |
+          # Dist directory is 'dist' by convention; kept for compatibility but not exported via deprecated set-output
+          echo "dist directory prepared"
+
+  # Verify Release Job: Download release assets and smoke-test the binaries
+  verify_release:
+    name: Verify Release Binaries Work
+    runs-on: ${{ matrix.os }}
+    needs: package
+    strategy:
+      matrix:
+        os: [ubuntu-latest, macos-latest]
+    steps:
+      - name: Checkout repository (ensure .git present)
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Install GitHub CLI (if missing)
+        run: |
+          if command -v gh >/dev/null 2>&1; then
+            gh --version
+          elif [ "$RUNNER_OS" = "macOS" ]; then
+            brew install gh || true
+          else
+            sudo apt-get update
+            sudo apt-get install -y gh || true
+          fi
+
+      - name: Create download directory
+        run: mkdir -p release_bin
+
+      - name: Download release asset
+        run: |
+          # Compute OS label and architecture to download the matching archive
+          if [ "${{ matrix.os }}" = "macos-latest" ]; then
+            os="darwin"
+          else
+            os="linux"
+          fi
+          arch=$(uname -m)
+          case "$arch" in
+            x86_64) arch="amd64" ;;
+            aarch64|arm64) arch="arm64" ;;
+            *) arch="$arch" ;;
+          esac
+
+          echo "Looking for release assets for OS=$os ARCH=$arch"
+
+          # Try to download the OS/arch-specific tarball first
+          gh release download "${{ github.ref_name }}" --repo "${{ github.repository }}" --pattern "*_${os}_*${arch}*.tar.gz" --dir release_bin || true
+
+          # If nothing downloaded, fall back to any tar.gz
+          if ! ls release_bin/*.tar.gz >/dev/null 2>&1; then
+            echo "No OS-specific tarball found, downloading all tar.gz archives as fallback"
+            gh release download "${{ github.ref_name }}" --repo "${{ github.repository }}" --pattern "*.tar.gz" --dir release_bin || true
+          fi
+
+          echo "Downloaded files:"; ls -la release_bin || true
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract and run binary
+        run: |
+          echo "Debug: list downloaded release_bin before extraction"
+          ls -la release_bin || true
+
+          echo "Extracting all tarballs from release_bin"
+          for t in release_bin/*.tar.gz; do
+            [ -f "$t" ] || continue
+            echo "Extracting $t"
+            tar -xzf "$t" -C release_bin || true
+          done
+
+          echo "Searching for fmsh executable"
+          # Prefer an executable file named exactly 'fmsh'
+          bin=$(find release_bin -type f -name 'fmsh' -perm -u+x -print -quit)
+          # If not found, look for any executable matching 'fmsh*'
+          if [ -z "$bin" ]; then
+            bin=$(find release_bin -type f -executable -name 'fmsh*' -print -quit)
+          fi
+
+          if [ -z "$bin" ]; then
+            echo "ERROR: no executable fmsh binary found after extraction" >&2
+            find release_bin || true
+            exit 1
+          fi
+
+          echo "Found binary: $bin"
+          chmod +x "$bin"
+          "$bin" --version || "$bin" --help
+
+      - name: (Ubuntu) Download and install .deb and verify
+        if: matrix.os == 'ubuntu-latest'
+        run: |
+          # Download any .deb assets from the release
+          gh release download ${{ github.ref_name }} --pattern "*.deb" --dir release_bin
+          ls -l release_bin || true
+          if compgen -G "release_bin/*.deb" > /dev/null; then
+            sudo dpkg -i release_bin/*.deb || true
+            # Install missing deps if needed
+            sudo apt-get update || true
+            sudo apt-get install -f -y || true
+            # Verify the installed fmsh is callable
+            if command -v fmsh >/dev/null 2>&1; then
+              fmsh --version || fmsh --help
+            else
+              echo "ERROR: fmsh not found after .deb install" >&2
+              exit 1
+            fi
+          else
+            echo "No .deb assets found for installation"; exit 0
+          fi
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify binary version matches tag
+        run: |
+          # Prefer the installed binary if present, otherwise the release binary
+          if command -v fmsh >/dev/null 2>&1; then
+            out=$(fmsh --version || true)
+          else
+            bin=$(find release_bin -type f -name 'fmsh' -print -quit)
+            if [ -z "$bin" ]; then
+              bin=$(find release_bin -type f -executable -name 'fmsh*' -print -quit)
+            fi
+            out=$("$bin" --version || true)
+          fi
+          echo "Binary version output: $out"
+          # Basic check: tag name should appear in version output
+          if echo "$out" | grep -q "${{ github.ref_name }}"; then
+            echo "Version string matches tag"
+          else
+            echo "WARNING: version string does not contain tag (${{ github.ref_name }})" || true
+          fi
 
   # Deploy APT Repository Job
   deploy_apt:
     runs-on: ubuntu-latest
-    needs: package
+    needs: verify_release
     steps:
-      - name: Checkout Code
+      - name: Checkout gh-pages branch (with full history)
         uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+          ref: gh-pages
+
+      - name: Install dpkg-dev (for dpkg-scanpackages)
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y dpkg-dev
 
       - name: Prepare APT Repository
         run: |
@@ -86,25 +253,27 @@ jobs:
 
       - name: Generate Release File
         run: |
-          cat <<EOF > docs/apt/dists/stable/Release
-          Origin: fmsh
-          Label: fmsh
-          Suite: stable
-          Codename: stable
-          Architectures: amd64 arm64
-          Components: main
-          Description: APT repository for fmsh
-          EOF
-
-      - name: Ensure gh-pages Branch is Checked Out
-        run: |
-          git fetch origin
-          git checkout gh-pages || git checkout --orphan gh-pages
+          mkdir -p docs/apt/dists/stable
+          echo 'Origin: fmsh' > docs/apt/dists/stable/Release
+          echo 'Label: fmsh' >> docs/apt/dists/stable/Release
+          echo 'Suite: stable' >> docs/apt/dists/stable/Release
+          echo 'Codename: stable' >> docs/apt/dists/stable/Release
+          echo 'Architectures: amd64 arm64' >> docs/apt/dists/stable/Release
+          echo 'Components: main' >> docs/apt/dists/stable/Release
+          echo 'Description: APT repository for fmsh' >> docs/apt/dists/stable/Release
 
       - name: Commit and Push to gh-pages
         run: |
-          git config --global user.name "GitHub Actions"
-          git config --global user.email "actions@github.com"
-          git add docs/
-          git commit -m "Update APT repository in /docs for GitHub Pages"
-          git push https://${{ secrets.GITHUB_TOKEN }}@github.com/Agent-Hellboy/fmsh.git gh-pages
+          # Ensure we're in the workspace and .git exists before running git
+          if [ -n "$GITHUB_WORKSPACE" ]; then
+            cd "$GITHUB_WORKSPACE"
+          fi
+          if [ -d ".git" ]; then
+            git config --global user.name "GitHub Actions"
+            git config --global user.email "actions@github.com"
+            git add docs/
+            git commit -m "Update APT repository in /docs for GitHub Pages" || echo "No changes to commit"
+            git push origin gh-pages || echo "Nothing to push or push failed"
+          else
+            echo "No .git directory present in $GITHUB_WORKSPACE; skipping commit/push to gh-pages"
+          fi

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,7 +25,9 @@ jobs:
       - name: Set Up Go
         uses: actions/setup-go@v5
         with:
-          go-version: '1.21.4'
+          # Prefer the version from go.mod to avoid drift
+          go-version-file: go.mod
+          cache: true
 
       - name: Download modules
         run: go mod download
@@ -64,6 +66,13 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
+
+      - name: Set Up Go
+        uses: actions/setup-go@v5
+        with:
+          # Prefer the version from go.mod to avoid drift
+          go-version-file: go.mod
+          cache: true
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v5

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,21 +35,16 @@ jobs:
       - name: Build binary
         run: |
           mkdir -p dist
-          # Use RUNNER_OS to differentiate runner platforms (Linux vs macOS)
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            go build -o dist/fmsh-darwin-amd64 ./cmd
-          else
-            go build -o dist/fmsh-linux-amd64 ./cmd
-          fi
+          goos=$(go env GOOS)
+          goarch=$(go env GOARCH)
+          go build -o "dist/fmsh-${goos}-${goarch}" ./cmd
 
       - name: Set artifact name
         id: set-name
         run: |
-          if [ "$RUNNER_OS" = "macOS" ]; then
-            echo "name=macos" >> $GITHUB_OUTPUT
-          else
-            echo "name=linux" >> $GITHUB_OUTPUT
-          fi
+          goos=$(go env GOOS)
+          goarch=$(go env GOARCH)
+          echo "name=${goos}-${goarch}" >> $GITHUB_OUTPUT
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,12 +18,12 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Set Up Go
-        uses: actions/setup-go@v4
+        uses: actions/setup-go@v5
         with:
           go-version: '1.21.4'
 
@@ -61,12 +61,12 @@ jobs:
     needs: build
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v4
+        uses: goreleaser/goreleaser-action@v5
         with:
           distribution: goreleaser
           version: latest
@@ -93,7 +93,7 @@ jobs:
         os: [ubuntu-latest, macos-latest]
     steps:
       - name: Checkout repository (ensure .git present)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
@@ -221,7 +221,7 @@ jobs:
     needs: verify_release
     steps:
       - name: Checkout gh-pages branch (with full history)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
           ref: gh-pages

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,9 +17,10 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Set up Go
-      uses: actions/setup-go@v4
+      uses: actions/setup-go@v5
       with:
-        go-version: '1.21.4'
+        go-version-file: go.mod
+        cache: true
 
     - name: Build
       run: go build -o fmsh ./cmd

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,3 @@
-# If you prefer the allow list template instead of the deny list, see community template:
-# https://github.com/github/gitignore/blob/main/community/Golang/Go.AllowList.gitignore
-#
 # Binaries for programs and plugins
 *.exe
 *.exe~
@@ -23,3 +20,6 @@ go.work.sum
 
 # env file
 .env
+
+# Ignore build artifacts
+dist/

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -1,5 +1,4 @@
 version: 2
-
 project_name: fmsh
 
 builds:
@@ -22,17 +21,21 @@ universal_binaries:
   - id: fmsh-universal
     replace: true
 
-brews:
-  - name: fmsh
-    homepage: "https://github.com/Agent-Hellboy/fmsh"
-    description: "File Management Shell"
-    license: "GPL-3.0"
-    repository:
-      owner: "Agent-Hellboy"
-      name: "fmsh"
-    commit_author:
-      name: "Prince Roshan"
-      email: "princekrroshan01@gmail.com"
+## Homebrew publishing disabled for fork testing
+## Keep this commented in forks to avoid attempting to push formulae to the upstream
+## repository (Agent-Hellboy/fmsh). When merged upstream, the maintainer can
+## safely uncomment and configure the appropriate secret (HOMEBREW_GITHUB_TOKEN).
+# brews:
+#   - name: fmsh
+#     homepage: "https://github.com/Agent-Hellboy/fmsh"
+#     description: "File Management Shell"
+#     license: "GPL-3.0"
+#     repository:
+#       owner: "Agent-Hellboy"
+#       name: "fmsh"
+#     commit_author:
+#       name: "Prince Roshan"
+#       email: "princekrroshan01@gmail.com"
 
 nfpms:
   - id: deb-package

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -21,21 +21,17 @@ universal_binaries:
   - id: fmsh-universal
     replace: true
 
-## Homebrew publishing disabled for fork testing
-## Keep this commented in forks to avoid attempting to push formulae to the upstream
-## repository (Agent-Hellboy/fmsh). When merged upstream, the maintainer can
-## safely uncomment and configure the appropriate secret (HOMEBREW_GITHUB_TOKEN).
-# brews:
-#   - name: fmsh
-#     homepage: "https://github.com/Agent-Hellboy/fmsh"
-#     description: "File Management Shell"
-#     license: "GPL-3.0"
-#     repository:
-#       owner: "Agent-Hellboy"
-#       name: "fmsh"
-#     commit_author:
-#       name: "Prince Roshan"
-#       email: "princekrroshan01@gmail.com"
+brews:
+  - name: fmsh
+    homepage: "https://github.com/Agent-Hellboy/fmsh"
+    description: "File Management Shell"
+    license: "GPL-3.0"
+    repository:
+      owner: "Agent-Hellboy"
+      name: "fmsh"
+    commit_author:
+      name: "Prince Roshan"
+      email: "princekrroshan01@gmail.com"
 
 nfpms:
   - id: deb-package


### PR DESCRIPTION
# chore(ci): Add release workflow and update GoReleaser config

This PR adds a GitHub Actions workflow to automate the release process using GoReleaser. It builds the binaries for Linux and macOS, creates GitHub Releases with artifacts, and verifies the release binaries by running some basic checks.


### What’s included in this PR:

- `.github/workflows/release.yml`: The GitHub Actions workflow that runs on tag pushes (`v*`). It:
  - Checks out the code.
  - Sets up Go environment.
  - Builds binaries for Linux and macOS.
  - Uploads build artifacts.
  - Runs GoReleaser to create GitHub Releases.
  - Downloads the released assets and verifies their functionality.
  - Prepares and deploys an APT repository for `.deb` packages.
  
- `.goreleaser.yml`: GoReleaser configuration updated with:
  - Build targets for Linux and macOS (amd64 and arm64).
  - Release settings including pre-release detection.
  - Packaging configurations for `.deb` and optional Homebrew (commented out by default).


### Notes for the Maintainer:

To enable the release workflow fully, a **GitHub Personal Access Token (PAT)** needs to be created and added as a secret named `GH_PAT` in the repository’s Settings → Secrets.

**Required permissions for the token:**

- `repo` scope — to create and manage releases and upload release assets.
- `workflow` scope — to trigger and manage workflows if needed.

Optionally, to enable Homebrew publishing (currently commented out for safety), the maintainer can create another token with the `repo` scope and add it as `HOMEBREW_GITHUB_TOKEN`.


### Why are some parts commented out?

The Homebrew publishing section is commented out to prevent accidental pushes to the upstream formula repository from forks. Once this PR is merged upstream and the maintainer is ready, they can safely uncomment and configure the Homebrew publishing with the appropriate token.


### Testing:

All steps have been tested locally, including building, packaging, and verifying the binaries. The workflow is designed to trigger only on tag pushes following the pattern `v*` to prevent unintended releases.

### Screenshots 

<img width="1912" height="834" alt="Screenshot 2025-10-11 025639" src="https://github.com/user-attachments/assets/e6bcbb73-9fbe-4841-940c-ef163d4ed293" />

<img width="1707" height="874" alt="Screenshot 2025-10-11 023519" src="https://github.com/user-attachments/assets/bbb0f01b-eb14-466d-8b54-6e4431d8a878" />

Fixes
#4 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- New Features
  - Added macOS and Linux release binaries with platform-specific artifacts and published Debian packages in a versioned APT layout.

- Tests
  - Automated verification of released binaries across OS/architectures, including extraction and version checks and optional .deb install validation.

- Chores
  - CI moved to matrix builds, updated action versions, improved artifact naming/upload, hardened release/publish steps, and ignored build artifacts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->