### PR TITLE
docs: drop README logo image and add project CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,20 @@
+# fmsh — working notes for Claude
+
+fmsh is a macOS-only **black box recorder for AI-driven development**: a local
+`fmshd` daemon records filesystem/process/port/git/risk events into SQLite, and
+the CLI queries them. See `README.md` for the full product overview and the
+package layout under `cmd/fmsh` and `internal/`.
+
+## Discovery & refactoring
+
+For code search, discovery, or understanding relationships across the codebase,
+prefer `graphify query <question>` over grep loops. The knowledge graph is built
+on the first query (~1–2 min) and cached for the session. Examples:
+"trace the event pipeline from collector to store", "where is RiskConfig used",
+"how are sessions closed".
+
+## Conventions
+
+- macOS-only; no sudo for the daemon (only `fmsh restore` mounts a snapshot).
+- Pure-Go SQLite (`modernc.org/sqlite`), so builds run with `CGO_ENABLED=0`.
+- Run `gofmt`, `go vet ./...`, and `go test ./...` before pushing.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,3 @@
-<p align="center">
-  <img src="fmsh.png" alt="fmsh" width="320"/>
-</p>
-
 <h1 align="center">fmsh — Forensic Machine Shell</h1>
 
 <p align="center"><b>A black box recorder for AI-driven development on macOS.</b></p>


### PR DESCRIPTION
- Remove the fmsh.png banner from the README header
- Add a concise CLAUDE.md (graphify-first discovery + build conventions); dropped the obsolete pre-implementation architecture-checkpoint note

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a new note with project guidance and development conventions for the app.
  * Updated the README by removing the top logo image for a cleaner opening layout.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->